### PR TITLE
Setting the chevron from within the styling now

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 - Tapping an action now triggers a dismiss of the notification. This also fixes the issue where actions would be called multiple times.
 - Chevron image is now having a max size of 20x20.
 - Some small memory fixes
+- Chevron image is now set inside the style, which is more logic.
 
 ### 1.0 (2017-07-14)
 

--- a/Example/UINotifications-Example/ViewController.swift
+++ b/Example/UINotifications-Example/ViewController.swift
@@ -49,6 +49,10 @@ enum NotificationStyle: UINotificationStyle {
     var interactive: Bool {
         return true
     }
+    
+    var chevronImage: UIImage? {
+        return #imageLiteral(resourceName: "iconToastChevron")
+    }
 }
 
 final class ViewController: UIViewController {
@@ -83,7 +87,7 @@ final class ViewController: UIViewController {
             })
         }
         
-        let notification = UINotification(content: UINotificationContent(title: content, chevronImage: #imageLiteral(resourceName: "iconToastChevron")), style: style, action: action)
+        let notification = UINotification(content: UINotificationContent(title: content), style: style, action: action)
         
         UINotificationCenter.current.show(notification: notification, dismissTrigger: dismissTrigger)
     }

--- a/Sources/UINotification.swift
+++ b/Sources/UINotification.swift
@@ -25,6 +25,9 @@ public protocol UINotificationStyle {
     
     /// When `true`, the notification is swipeable and tappable.
     var interactive: Bool { get }
+    
+    /// The chevron image which is shown when a notification has an action attached.
+    var chevronImage: UIImage? { get }
 }
 
 /// Defines the height which will be applied on the notification view.
@@ -82,11 +85,7 @@ public struct UINotificationContent {
     /// The title which will be showed inside the notification.
     public let title: String
     
-    /// The chevron image which will be showed when a notification has an action.
-    public let chevronImage: UIImage?
-    
-    public init(title: String, chevronImage: UIImage? = nil) {
+    public init(title: String) {
         self.title = title
-        self.chevronImage = chevronImage
     }
 }

--- a/Sources/UINotificationStyles/UINotificationSystemStyle.swift
+++ b/Sources/UINotificationStyles/UINotificationSystemStyle.swift
@@ -15,4 +15,5 @@ public struct UINotificationSystemStyle: UINotificationStyle {
     public var textColor: UIColor = UIColor.black
     public var height: UINotificationHeight = .navigationBar
     public var interactive: Bool = true
+    public var chevronImage: UIImage?
 }

--- a/Sources/UINotificationView.swift
+++ b/Sources/UINotificationView.swift
@@ -33,7 +33,7 @@ open class UINotificationView: UIView {
     }()
     
     lazy internal var chevronImageView: UIImageView = {
-        let imageView = UIImageView(image: self.notification.content.chevronImage)
+        let imageView = UIImageView(image: self.notification.style.chevronImage)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
@@ -99,7 +99,7 @@ open class UINotificationView: UIView {
             titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
             chevronImageView.leftAnchor.constraint(equalTo: titleLabel.rightAnchor, constant: leftRightMargin),
             chevronImageView.rightAnchor.constraint(equalTo: rightAnchor, constant: hasAction ? -leftRightMargin : 0),
-            chevronImageView.widthAnchor.constraint(equalToConstant: hasAction ? (notification.content.chevronImage?.size.width ?? 0) : 0).usingPriority(UILayoutPriorityDefaultLow),
+            chevronImageView.widthAnchor.constraint(equalToConstant: hasAction ? (notification.style.chevronImage?.size.width ?? 0) : 0).usingPriority(UILayoutPriorityDefaultLow),
             chevronImageView.widthAnchor.constraint(lessThanOrEqualToConstant: 20),
             chevronImageView.heightAnchor.constraint(lessThanOrEqualToConstant: 20),
             chevronImageView.centerYAnchor.constraint(equalTo: centerYAnchor)

--- a/Tests/UINotificationsTests/UINotificationDefaultElementsTests.swift
+++ b/Tests/UINotificationsTests/UINotificationDefaultElementsTests.swift
@@ -12,13 +12,14 @@ import XCTest
 final class UINotificationDefaultElementsTests: UINotificationTestCase {
 
     struct CustomStyle: UINotificationStyle {
-        public var font: UIFont = UIFont.systemFont(ofSize: 13, weight: UIFontWeightSemibold)
-        public var backgroundColor: UIColor = UIColor.white
-        public var textColor: UIColor = UIColor.black
-        public var height: UINotificationHeight {
+        var font: UIFont = UIFont.systemFont(ofSize: 13, weight: UIFontWeightSemibold)
+        var backgroundColor: UIColor = UIColor.white
+        var textColor: UIColor = UIColor.black
+        var height: UINotificationHeight {
             return UINotificationHeight.custom(height: self.customHeight)
         }
-        public var interactive: Bool = true
+        var interactive: Bool = true
+        var chevronImage: UIImage?
         
         let customHeight: CGFloat
         

--- a/Tests/UINotificationsTests/UINotificationDefaultViewTests.swift
+++ b/Tests/UINotificationsTests/UINotificationDefaultViewTests.swift
@@ -74,12 +74,26 @@ final class UINotificationViewTests: UINotificationTestCase {
     
     /// It should size the chevron image correctly.
     func testChevronImageSizes() {
-        let bundle = Bundle(for: UINotificationViewTests.self)
-        let image = UIImage(named: "iconToastChevron", in: bundle, compatibleWith: nil)
-        let content = UINotificationContent(title: "title", chevronImage: image)
-        notification.update(content)
+        
+        let content = UINotificationContent(title: "title")
+        let style = LargeChevronStyle()
+        let notification = UINotification(content: content, style: style, action: nil)
         let notificationView = UINotificationView(notification: notification)
         notificationView.layoutIfNeeded()
-        XCTAssert(notificationView.chevronImageView.bounds.size != image!.size, "Size should not inherit from the chevron image, but keep the designed size.")
+        XCTAssert(notificationView.chevronImageView.bounds.size != style.chevronImage!.size, "Size should not inherit from the chevron image, but keep the designed size.")
+    }
+}
+
+private struct LargeChevronStyle: UINotificationStyle {
+    var font: UIFont = UIFont.systemFont(ofSize: 13, weight: UIFontWeightSemibold)
+    var backgroundColor: UIColor = UIColor.white
+    var textColor: UIColor = UIColor.black
+    var height: UINotificationHeight {
+        return UINotificationHeight.navigationBar
+    }
+    var interactive: Bool = true
+    var chevronImage: UIImage? {
+        let bundle = Bundle(for: UINotificationViewTests.self)
+        return UIImage(named: "iconToastChevron", in: bundle, compatibleWith: nil)
     }
 }


### PR DESCRIPTION
The chevron image is now set from within the given style object. This is more logic, as you will probably only use one chevron image throughout your app.