### PR TITLE
Chevron is now hidden when no action attached

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@
 - Chevron image is now having a max size of 20x20.
 - Some small memory fixes
 - Chevron image is now set inside the style, which is more logic.
+- The chevron image is now hidden when there's no action attached.
 
 ### 1.0 (2017-07-14)
 

--- a/Sources/UINotificationView.swift
+++ b/Sources/UINotificationView.swift
@@ -86,6 +86,7 @@ open class UINotificationView: UIView {
         backgroundColor = notification.style.backgroundColor
         
         chevronImageView.tintColor = notification.style.textColor
+        chevronImageView.isHidden = notification.action == nil
         
         panGestureRecognizer.isEnabled = notification.style.interactive
         tapGestureRecognizer.isEnabled = notification.style.interactive


### PR DESCRIPTION
The chevron image is now hidden when there's no action attached.