### PR TITLE
Dismiss notifications after canceling drag

### DIFF
--- a/Sources/UINotificationView.swift
+++ b/Sources/UINotificationView.swift
@@ -132,6 +132,7 @@ open class UINotificationView: UIView {
                 presenter.dismiss()
             } else {
                 presenter.present()
+                (presenter.dismissTrigger as? UINotificationSchedulableDismissTrigger)?.schedule()
             }
         }
     }


### PR DESCRIPTION
If you dragged a notification with a UINotificationSchedulableDismissTrigger, it would never close when you stopped dragging it. This PR fixes that by simply scheduling the trigger again when the UIPanGestureRecognizer is cancelled or is ended. 