### PR TITLE
Fix tapping bug for iPhone X

### DIFF
--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -76,6 +76,6 @@ extension UINotificationCenter: UINotificationQueueDelegate {
 internal final class UINotificationPresentationWindow: UIWindow {
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         guard let rootViewController = self.rootViewController, let notificationView = rootViewController.view.subviews.first(where: { $0 is UINotificationView }) else { return false }
-        return notificationView.point(inside: point, with: event)
+        return notificationView.frame.contains(point)
     }
 }

--- a/UINotificationsTests/UINotificationCenterTests.swift
+++ b/UINotificationsTests/UINotificationCenterTests.swift
@@ -58,13 +58,4 @@ final class UINotificationCenterTests: UINotificationTestCase {
 
         waitFor(notificationCenter.currentPresenter == nil, timeout: 5.0, description: "Current presenter should be released and nil")
     }
-
-    /// It should correctly hit test points inside the custom window.
-    func testWindowHittesting() {
-        let notificationCenter = UINotificationCenter()
-        notificationCenter.presenterType = MockPresenter.self
-        notificationCenter.show(notification: notification)
-        XCTAssertFalse(notificationCenter.window.point(inside: CGPoint(x: 0, y: 0), with: nil))
-        XCTAssertTrue(notificationCenter.window.point(inside: CGPoint(x: 0, y: -10), with: nil))
-    }
 }

--- a/UINotificationsTests/UINotificationCenterTests.swift
+++ b/UINotificationsTests/UINotificationCenterTests.swift
@@ -58,5 +58,13 @@ final class UINotificationCenterTests: UINotificationTestCase {
 
         waitFor(notificationCenter.currentPresenter == nil, timeout: 5.0, description: "Current presenter should be released and nil")
     }
-    
+
+    /// It should correctly hit test points inside the custom window.
+    func testWindowHittesting() {
+        let notificationCenter = UINotificationCenter()
+        notificationCenter.presenterType = MockPresenter.self
+        notificationCenter.show(notification: notification)
+        XCTAssertFalse(notificationCenter.window.point(inside: CGPoint(x: 0, y: 0), with: nil))
+        XCTAssertTrue(notificationCenter.window.point(inside: CGPoint(x: 0, y: -10), with: nil))
+    }
 }

--- a/UINotificationsTests/UINotificationDefaultElementsTests.swift
+++ b/UINotificationsTests/UINotificationDefaultElementsTests.swift
@@ -105,9 +105,10 @@ final class UINotificationDefaultElementsTests: UINotificationTestCase {
         
         // Wait till the notification is presented
         waitFor(notificationCenter.currentPresenter?.dismissTrigger.target != nil, timeout: 5.0, description: "Dismiss trigger target should be set")
-        
-        XCTAssert(notificationCenter.currentPresenter?.presentationContext.containerWindow.point(inside: CGPoint(x: 0, y: 10), with: nil) == true, "Point inside the notification view should be handled")
-        let notificationViewFrame = notificationCenter.currentPresenter?.presentationContext.notificationView.frame
-        XCTAssert(notificationCenter.currentPresenter?.presentationContext.containerWindow.point(inside: CGPoint(x: 0, y: notificationViewFrame!.height + 10), with: nil) == false, "Point outside the notification view should not be handled")
+
+        let notificationViewFrameOrigin = notificationCenter.currentPresenter!.presentationContext.notificationView.frame.origin
+
+        XCTAssert(notificationCenter.currentPresenter?.presentationContext.containerWindow.point(inside: CGPoint(x: notificationViewFrameOrigin.x, y: notificationViewFrameOrigin.y + 1), with: nil) == true, "Point inside the notification view should be handled")
+        XCTAssert(notificationCenter.currentPresenter?.presentationContext.containerWindow.point(inside: CGPoint(x: notificationViewFrameOrigin.x, y: notificationViewFrameOrigin.y - 1), with: nil) == false, "Point outside the notification view should not be handled")
     }
 }


### PR DESCRIPTION
Fixes a bug where notifications weren't tappable.

Fixes #36 