### PR TITLE
Don't make notification window key as it could conflict with the main window

### DIFF
--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -31,7 +31,7 @@ public final class UINotificationCenter {
     // MARK: Private properties
     
     /// The window which will be placed on top of the application window.
-    /// This window is used to present the notifications on and will be hided when all notifications are presented.
+    /// This window is used to present the notifications on and will be hidden when all notifications are presented.
     internal let window: UIWindow
     
     /// Handles queueing of all notifications. Contains a queue of `UINotificationRequest` objects.

--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -31,7 +31,7 @@ public final class UINotificationCenter {
     // MARK: Private properties
     
     /// The window which will be placed on top of the application window.
-    /// This window is used to present the notifications on and will be hidden when all notifications are presented.
+    /// This window is used to present the notifications on and will be hidden when notifications are dismissed.
     internal let window: UIWindow
     
     /// Handles queueing of all notifications. Contains a queue of `UINotificationRequest` objects.

--- a/Sources/UINotificationPresentationContext.swift
+++ b/Sources/UINotificationPresentationContext.swift
@@ -52,7 +52,7 @@ public final class UINotificationPresentationContext {
     private func prepareContainerWindow() {
         containerWindow.windowLevel = windowLevel
         #if !TEST
-            containerWindow.makeKeyAndVisible()
+            containerWindow.isHidden = false
         #endif
     }
     
@@ -94,9 +94,6 @@ public final class UINotificationPresentationContext {
         /// Move the window behind the key application window.
         containerWindow.windowLevel = UIWindow.Level.normal - 1
         containerWindow.rootViewController = nil
-        
-        /// Make sure the key window of the app is visible again.
-        guard let applicationWindow = UIApplication.shared.windows.first(where: { $0 != self.containerWindow }) else { return }
-        applicationWindow.makeKeyAndVisible()
+        containerWindow.isHidden = true
     }
 }


### PR DESCRIPTION
### What's the problem?

We ran into an issue with an Authentication library and `ASWebAuthenticationSession`. The library would automatically use the applications `keyWindow` as the presentation anchor for the authentication session. If someone would trigger a login while a notification was presented the safari view controller presented by the authentication session would disappear as soon as the notification was dismissed. 

### What was causing the issue?

This happened because the notification window was the apps `keyWindow` while a notification was presented. As only one window at a time can be the key window the auth SDK was picking that window as the presentation anchor of the auth session. When the notification was dismissed the apps main window became key again and that would break the authentication flow.

### How it was solved?

It turns out that the `UINotificationWindow` does not have to be the key window. The only thing it needs is touch events, and those are always delivered to the window in which it occurred. The only requirement for that is that the window is visible. We also want notifications to be presented on top of the app. This is already managed by setting an appropriate window level for presentation (by default above the status bar). 

The only events that the window can't handle if it is not key are: 
- Motion (e.g. shake gesture)
- keyboard (e.g. text field)
- remote (not applicable)
- presses (physical key presses). 

Those are not relevant for the use case of presenting a simple in app notification.