### PR TITLE
Merge release 1.6.0 into master

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+### 1.6.0
+- Add support for presenting on window scenes ([#56](https://github.com/WeTransfer/UINotifications/pull/56)) via [@AvdLee](https://github.com/AvdLee)
+- Merge release 1.5.1 into master ([#55](https://github.com/WeTransfer/UINotifications/pull/55)) via [@wetransferplatform](https://github.com/wetransferplatform)
+
 ### 1.5.1
 - Fix some warnings related to `class` keyword. ([#54](https://github.com/WeTransfer/UINotifications/pull/54)) via [@kairadiagne](https://github.com/kairadiagne)
 - Merge release 1.5.0 into master ([#53](https://github.com/WeTransfer/UINotifications/pull/53)) via [@wetransferplatform](https://github.com/wetransferplatform)

--- a/UINotifications.podspec
+++ b/UINotifications.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
   spec.name             = 'UINotifications'
-  spec.version          = '1.5.1'
+  spec.version          = '1.6.0'
   spec.summary          = 'Present custom in-app notifications easily in Swift.'
   spec.description      = 'Present custom in-app notifications easily in Swift with simple and highly customizable APIs.'
 


### PR DESCRIPTION
Containing all the changes for our [**1.6.0 Release**](https://github.com/WeTransfer/UINotifications/releases/tag/1.6.0).