### PR TITLE
Fix content width bug

### DIFF
--- a/Sources/UINotificationPresentationContext.swift
+++ b/Sources/UINotificationPresentationContext.swift
@@ -73,8 +73,8 @@ public final class UINotificationPresentationContext {
         notificationView.topConstraint = notificationViewTopConstraint
         
         var constraints = [
-            notificationView.leftAnchor.constraint(equalTo: containerViewController.view.leftAnchor).usingPriority(.defaultHigh),
-            notificationView.rightAnchor.constraint(equalTo: containerViewController.view.rightAnchor).usingPriority(.defaultHigh),
+            notificationView.leftAnchor.constraint(equalTo: containerViewController.view.leftAnchor).usingPriority(.required),
+            notificationView.rightAnchor.constraint(equalTo: containerViewController.view.rightAnchor).usingPriority(.required),
             notificationView.heightAnchor.constraint(equalToConstant: notification.style.height.value),
             notificationViewTopConstraint
         ]


### PR DESCRIPTION
When the title and subtitle are too long, the notification banner isn't centered anymore, but gets off-screen.

Closes https://wetransfer.atlassian.net/browse/TMB-162