### PR TITLE
Add `Sendable` conformance and support for Concurrency

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/UINotifications.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/UINotifications.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "UINotifications"
+               BuildableName = "UINotifications"
+               BlueprintName = "UINotifications"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "UINotifications"
+            BuildableName = "UINotifications"
+            BlueprintName = "UINotifications"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/.swiftpm/xcode/xcshareddata/xcschemes/UINotifications.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/UINotifications.xcscheme
@@ -26,8 +26,13 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:UINotifications.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Example/UINotifications-Example.xcodeproj/project.pbxproj
+++ b/Example/UINotifications-Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -120,8 +120,9 @@
 		50042BC61F18BC85007209B7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1500;
 				ORGANIZATIONNAME = WeTransfer;
 				TargetAttributes = {
 					50042BCD1F18BC85007209B7 = {
@@ -166,6 +167,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		5078C7891F18C5A1006EB23F /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -216,6 +218,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -249,6 +252,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -277,6 +281,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -310,6 +315,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Example/UINotifications-Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Example/UINotifications-Example.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:UINotifications-Example.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Example/UINotifications-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/UINotifications-Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-concurrency-extras",
+        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "ea631ce892687f5432a833312292b80db238186a",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Example/UINotifications-Example/ViewController.swift
+++ b/Example/UINotifications-Example/ViewController.swift
@@ -49,7 +49,7 @@ enum NotificationStyle: UINotificationStyle {
     }
 
     var thumbnailSize: CGSize {
-        return .init(width: 50, height: 50)
+        return CGSize(width: 50, height: 50)
     }
 
     /// The height of the notification which applies on the notification view.
@@ -113,7 +113,15 @@ final class ViewController: UIViewController {
             })
         }
 
-        let notification = UINotification(content: UINotificationContent(title: title, subtitle: subtitle, image: image), style: style, action: action)
+        let notification = UINotification(
+            content: UINotificationContent(
+                title: title,
+                subtitle: subtitle,
+                image: image
+            ),
+            style: style,
+            action: action
+        )
 
         if addButtonSwitch.isOn {
             let button = UIButton(type: .system)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-concurrency-extras",
+        "repositoryURL": "https://github.com/pointfreeco/swift-concurrency-extras.git",
+        "state": {
+          "branch": null,
+          "revision": "ea631ce892687f5432a833312292b80db238186a",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -11,11 +11,17 @@ let package = Package(
     products: [
         .library(name: "UINotifications", targets: ["UINotifications"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-concurrency-extras.git", from: "1.0.0")
+    ],
     targets: [
         .target(name: "UINotifications", path: "Sources"),
         .testTarget(
             name: "UINotificationsTests",
-            dependencies: ["UINotifications"],
+            dependencies: [
+                "UINotifications",
+                .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras")
+            ],
             path: "Tests",
             resources: [.copy("Resources/iconToastChevron.png")]
         )

--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ manualDismissTrigger.trigger() // Dismiss
 - Set your custom view on the `UINotificationCenter`:
 
 ```swift
-UINotificationCenter.current.defaultNotificationViewType = MyCustomNotificationView.self
+UINotificationCenter.current.configuration = UINotificationCenterConfiguration(
+    defaultNotificationViewType: MyCustomNotificationView.self
+)
 ```
 
 ### Use a custom UIButton
@@ -163,7 +165,9 @@ Create a custom presenter to manage presentation and dismiss animations.
 - Set your custom presenter on the `UINotificationCenter`:
 
 ```swift
-UINotificationCenter.current.presenterType = MyCustomPresenter.self
+UINotificationCenter.current.configuration = UINotificationCenterConfiguration(
+    presenterType: MyCustomPresenter.self
+)
 ```
 
 *Checkout `UINotificationEaseOutEaseInPresenter` for an example.*
@@ -174,7 +178,9 @@ By default, notifications which are already queued will not be queued again. Thi
 To disable this setting:
 
 ```swift
-UINotificationCenter.current.isDuplicateQueueingAllowed = true
+UINotificationCenter.current.configuration = UINotificationCenterConfiguration(
+    isDuplicateQueueingAllowed: true
+)
 ```
 
 ## Communication

--- a/Sources/UINotification.swift
+++ b/Sources/UINotification.swift
@@ -39,6 +39,7 @@ public protocol UINotificationStyle: Sendable {
 }
 
 /// Handles changes in UINotification
+@MainActor
 protocol UINotificationDelegate: AnyObject {
     // Called when Notification is updated.
     func didUpdateContent(in notificaiton: UINotification)
@@ -61,8 +62,9 @@ public final class UINotification: Equatable, @unchecked Sendable {
     public enum Height: Sendable {
         case statusBar
         case navigationBar
-        case custom(height: CGFloat)
+        case custom(height:   CGFloat)
 
+        @MainActor
         internal var value: CGFloat {
             switch self {
             case .statusBar:
@@ -90,7 +92,9 @@ public final class UINotification: Equatable, @unchecked Sendable {
     /// Setting this property will add the button, even if the notification is already visible.
     public var button: UIButton? {
         didSet {
-            delegate?.didUpdateButton(in: self)
+            Task { @MainActor in
+                delegate?.didUpdateButton(in: self)
+            }
         }
     }
     
@@ -110,7 +114,9 @@ public final class UINotification: Equatable, @unchecked Sendable {
         Self.lockQueue.sync {
             self.notificationContent = content
         }
-        delegate?.didUpdateContent(in: self)
+        Task { @MainActor in
+            delegate?.didUpdateContent(in: self)
+        }
     }
     
     public static func == (lhs: UINotification, rhs: UINotification) -> Bool {

--- a/Sources/UINotification.swift
+++ b/Sources/UINotification.swift
@@ -62,7 +62,7 @@ public final class UINotification: Equatable, @unchecked Sendable {
     public enum Height: Sendable {
         case statusBar
         case navigationBar
-        case custom(height:   CGFloat)
+        case custom(height: CGFloat)
 
         @MainActor
         internal var value: CGFloat {

--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -32,7 +32,7 @@ public struct UINotificationCenterConfiguration {
     ///   Changing the window level while a notification is displayed might give some issues.
     ///   - isDuplicateQueueingAllowed: If `true`, the same notifications can be queued. This can result in duplicate notifications
     ///   being presented after each other.
-    init(
+    public init(
         presenterType: UINotificationPresenter.Type = UINotificationEaseOutEaseInPresenter.self,
         defaultNotificationViewType: UINotificationView.Type = UINotificationView.self,
         windowLevel: UIWindow.Level = UIWindow.Level.statusBar,

--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -46,7 +46,7 @@ public struct UINotificationCenterConfiguration {
 }
 
 /// Handles the queueing and presenting of `UINotification`s
-public final class UINotificationCenter {
+public final class UINotificationCenter: @unchecked Sendable {
 
     // MARK: Public properties
 

--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -8,26 +8,55 @@
 
 import UIKit
 
+public struct UINotificationCenterConfiguration {
+    /// The type of presenter to use for presenting notifications. Change this to change the way notifications need to be presented.
+    let presenterType: UINotificationPresenter.Type
+
+    /// The type of view which will be used to present the notifications if not overriden by the `show` method.
+    let defaultNotificationViewType: UINotificationView.Type
+
+    /// The window level that notification should appear at. The default level is over the status bar.
+    /// Changing the window level while a notification is displayed might give some issues.
+    let windowLevel: UIWindow.Level
+
+    /// If `true`, the same notifications can be queued. This can result in duplicate notifications being presented after each other.
+    let isDuplicateQueueingAllowed: Bool
+
+    /// Creates a new notification center configuration.
+    /// - Parameters:
+    ///   - presenterType: The type of presenter to use for presenting notifications. 
+    ///   Change this to change the way notifications need to be presented.
+    ///   - defaultNotificationViewType: The type of view which will be used to present the notifications if not 
+    ///   overriden by the `show` method.
+    ///   - windowLevel: The window level that notification should appear at. The default level is over the status bar.
+    ///   Changing the window level while a notification is displayed might give some issues.
+    ///   - isDuplicateQueueingAllowed: If `true`, the same notifications can be queued. This can result in duplicate notifications
+    ///   being presented after each other.
+    init(
+        presenterType: UINotificationPresenter.Type = UINotificationEaseOutEaseInPresenter.self,
+        defaultNotificationViewType: UINotificationView.Type = UINotificationView.self,
+        windowLevel: UIWindow.Level = UIWindow.Level.statusBar,
+        isDuplicateQueueingAllowed: Bool = false
+    ) {
+        self.presenterType = presenterType
+        self.defaultNotificationViewType = defaultNotificationViewType
+        self.windowLevel = windowLevel
+        self.isDuplicateQueueingAllowed = isDuplicateQueueingAllowed
+    }
+}
+
 /// Handles the queueing and presenting of `UINotification`s
+@MainActor
 public final class UINotificationCenter {
+
+    // MARK: Public properties
 
     /// The `UINotificationCenter` for the current application
     public static let current = UINotificationCenter()
-    
-    // MARK: Public properties
-    /// The type of presenter to use for presenting notifications. Change this to change the way notifications need to be presented.
-    public var presenterType: UINotificationPresenter.Type = UINotificationEaseOutEaseInPresenter.self
-    
-    /// The type of view which will be used to present the notifications if not overriden by the `show` method.
-    public var defaultNotificationViewType: UINotificationView.Type = UINotificationView.self
-    
-    /// The window level that notification should appear at. The default level is over the status bar.
-    /// Changing the window level while a notification is displayed might give some issues.
-    public var windowLevel: UIWindow.Level = UIWindow.Level.statusBar
-    
-    /// If `true`, the same notifications can be queued. This can result in duplicate notifications being presented after each other.
-    public var isDuplicateQueueingAllowed: Bool = false
-    
+
+    /// The configuration to use for presenting notifications.
+    public var configuration = UINotificationCenterConfiguration()
+
     // MARK: Private properties
     
     /// The window which will be placed on top of the application window.
@@ -35,7 +64,9 @@ public final class UINotificationCenter {
     internal lazy var window: UIWindow = {
         let window: UIWindow
         
-        if let windowScene = UIApplication.shared.connectedScenes.first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene {
+        if let windowScene = UIApplication.shared.connectedScenes.first(
+            where: { $0.activationState == .foregroundActive }
+        ) as? UIWindowScene {
             window = UINotificationPresentationWindow(windowScene: windowScene)
         } else {
             window = UINotificationPresentationWindow()
@@ -53,15 +84,24 @@ public final class UINotificationCenter {
     
     /// Defines the current running presenter.
     internal weak var currentPresenter: UINotificationPresenter?
-    
+
     /// Request to present the given notification.
     ///
     /// - Parameter notification: The notification to be presented.
     /// - Parameter notificationViewType: Optional notification view type which overrides the default notification view type.
     /// - Parameter dismissTrigger: Optional dismiss trigger to use for the animation. If `nil` the default trigger will be used.
     /// - Returns: An `UINotificationRequest` for the requested notification presentation. Can be cancelled using `cancel()`.
-    @discardableResult public func show(notification: UINotification, notificationViewType: UINotificationView.Type? = nil, dismissTrigger: UINotificationDismissTrigger? = nil) -> UINotificationRequest {
-        return queue.add(notification, notificationViewType: notificationViewType ?? defaultNotificationViewType, dismissTrigger: dismissTrigger, allowDuplicates: isDuplicateQueueingAllowed)
+    @discardableResult public func show(
+        notification: UINotification,
+        notificationViewType: UINotificationView.Type? = nil,
+        dismissTrigger: UINotificationDismissTrigger? = nil
+    ) -> UINotificationRequest {
+        return queue.add(
+            notification,
+            notificationViewType: notificationViewType ?? configuration.defaultNotificationViewType,
+            dismissTrigger: dismissTrigger,
+            allowDuplicates: configuration.isDuplicateQueueingAllowed
+        )
     }
     
 }
@@ -70,18 +110,28 @@ extension UINotificationCenter: UINotificationQueueDelegate {
     /// Handles the request which is ready to be presented. Links the presenter to the `UINotification` and `UINotificationView`.
     internal func handle(_ request: UINotificationRequest) {
         let notificationView = request.notificationViewType.init(notification: request.notification)
-        let presentationContext = UINotificationPresentationContext(request: request, containerWindow: window, windowLevel: windowLevel, notificationView: notificationView)
-        let presenter = presenterType.init(presentationContext: presentationContext, dismissTrigger: request.dismissTrigger)
+        let presentationContext = UINotificationPresentationContext(
+            request: request,
+            containerWindow: window,
+            windowLevel: configuration.windowLevel,
+            notificationView: notificationView
+        )
+        let presenter = configuration.presenterType.init(presentationContext: presentationContext, dismissTrigger: request.dismissTrigger)
         notificationView.presenter = presenter
         currentPresenter = presenter
         presenter.present()
     }
 }
 
-/// A custom `UIWindow` to use for the presentatation of the notifications. Will make sure the UI touches are only forwarded when inside any presented notification.
+/// A custom `UIWindow` to use for the presentatation of the notifications. 
+/// Will make sure the UI touches are only forwarded when inside any presented notification.
 internal final class UINotificationPresentationWindow: UIWindow {
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        guard let rootViewController = self.rootViewController, let notificationView = rootViewController.view.subviews.first(where: { $0 is UINotificationView }) else { return false }
+        guard 
+            let rootViewController = self.rootViewController,
+            let notificationView = rootViewController.view.subviews.first(where: { $0 is UINotificationView }) else {
+            return false
+        }
         return notificationView.frame.contains(point)
     }
 }

--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -46,7 +46,6 @@ public struct UINotificationCenterConfiguration {
 }
 
 /// Handles the queueing and presenting of `UINotification`s
-@MainActor
 public final class UINotificationCenter {
 
     // MARK: Public properties
@@ -109,17 +108,19 @@ public final class UINotificationCenter {
 extension UINotificationCenter: UINotificationQueueDelegate {
     /// Handles the request which is ready to be presented. Links the presenter to the `UINotification` and `UINotificationView`.
     internal func handle(_ request: UINotificationRequest) {
-        let notificationView = request.notificationViewType.init(notification: request.notification)
-        let presentationContext = UINotificationPresentationContext(
-            request: request,
-            containerWindow: window,
-            windowLevel: configuration.windowLevel,
-            notificationView: notificationView
-        )
-        let presenter = configuration.presenterType.init(presentationContext: presentationContext, dismissTrigger: request.dismissTrigger)
-        notificationView.presenter = presenter
-        currentPresenter = presenter
-        presenter.present()
+        Task { @MainActor in
+            let notificationView = request.notificationViewType.init(notification: request.notification)
+            let presentationContext = UINotificationPresentationContext(
+                request: request,
+                containerWindow: window,
+                windowLevel: configuration.windowLevel,
+                notificationView: notificationView
+            )
+            let presenter = configuration.presenterType.init(presentationContext: presentationContext, dismissTrigger: request.dismissTrigger)
+            notificationView.presenter = presenter
+            currentPresenter = presenter
+            presenter.present()
+        }
     }
 }
 

--- a/Sources/UINotificationCenter.swift
+++ b/Sources/UINotificationCenter.swift
@@ -46,6 +46,8 @@ public struct UINotificationCenterConfiguration {
 }
 
 /// Handles the queueing and presenting of `UINotification`s
+/// `@unchecked Sendable` since all its mutation happens either on the Main Actor or
+/// is unlikely going to be in sequence with write operations.
 public final class UINotificationCenter: @unchecked Sendable {
 
     // MARK: Public properties

--- a/Sources/UINotificationDismissTrigger.swift
+++ b/Sources/UINotificationDismissTrigger.swift
@@ -9,18 +9,21 @@
 import Foundation
 
 /// Defines a dismissable view.
-public protocol Dismissable: AnyObject {
+@MainActor
+public protocol Dismissable: AnyObject, Sendable {
     /// Dimisses the view.
     func dismiss()
 }
 
 /// A trigger which can be used to dismiss an `UINotificationView`.
-public protocol UINotificationDismissTrigger: AnyObject {
+@MainActor
+public protocol UINotificationDismissTrigger: AnyObject, Sendable {
     /// The target to dismiss.
     var target: Dismissable? { get set }
 }
 
 /// A trigger which is schedulable and therefor cancelable.
+@MainActor
 public protocol UINotificationSchedulableDismissTrigger: UINotificationDismissTrigger {
     /// Schedules the dismiss trigger to let the notification animate out after the `displayDuration`.
     func schedule()

--- a/Sources/UINotificationDismissTriggers/UINotificationDurationDismissTrigger.swift
+++ b/Sources/UINotificationDismissTriggers/UINotificationDurationDismissTrigger.swift
@@ -22,7 +22,7 @@ public final class UINotificationDurationDismissTrigger: UINotificationSchedulab
     public init(duration: TimeInterval) {
         self.duration = duration
     }
-    
+
     public func schedule() {
         let dismissWorkItem = DispatchWorkItem { [weak self] in
             self?.target?.dismiss()

--- a/Sources/UINotificationPresentationContext.swift
+++ b/Sources/UINotificationPresentationContext.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 /// Provides information about an in-progress notification presentation.
+@MainActor
 public final class UINotificationPresentationContext {
 
     /// The window in which the `UINotificationView` will be presented.

--- a/Sources/UINotificationPresenter.swift
+++ b/Sources/UINotificationPresenter.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// The state of a notification presenter.
-public enum UINotificationPresenterState {
+public enum UINotificationPresenterState: Sendable {
     /// Ready to be presented.
     case idle
     /// Currently animating out.
@@ -23,7 +23,8 @@ public enum UINotificationPresenterState {
 }
 
 /// Defines a protocol for a UINotification presenter & dismisser.
-public protocol UINotificationPresenter: Dismissable {
+@MainActor
+public protocol UINotificationPresenter: Dismissable, Sendable {
     /// Provides information about an in-progress notification presentation.
     var presentationContext: UINotificationPresentationContext { get }
     

--- a/Sources/UINotificationPresenters/UINotificationEaseInOutPresenter.swift
+++ b/Sources/UINotificationPresenters/UINotificationEaseInOutPresenter.swift
@@ -55,17 +55,19 @@ public final class UINotificationEaseOutEaseInPresenter: UINotificationPresenter
         })
     }
 
-    public func dismiss() {
-        guard state == .presented else { return }
-        state = .dismissing
+    public nonisolated func dismiss() {
+        Task { @MainActor in
+            guard state == .presented else { return }
+            state = .dismissing
 
-        presentationContext.notificationView.topConstraint?.constant = -presentationContext.notification.style.height.value
+            presentationContext.notificationView.topConstraint?.constant = -presentationContext.notification.style.height.value
 
-        UIView.animate(withDuration: outDuration, delay: 0, options: UIView.AnimationOptions.curveEaseIn, animations: {
-            self.presentationContext.containerWindow.layoutIfNeeded()
-        }, completion: { (_) in
-            self.state = .idle
-            self.presentationContext.completePresentation()
-        })
+            UIView.animate(withDuration: outDuration, delay: 0, options: UIView.AnimationOptions.curveEaseIn, animations: {
+                self.presentationContext.containerWindow.layoutIfNeeded()
+            }, completion: { (_) in
+                self.state = .idle
+                self.presentationContext.completePresentation()
+            })
+        }
     }
 }

--- a/Sources/UINotificationQueue.swift
+++ b/Sources/UINotificationQueue.swift
@@ -8,9 +8,8 @@
 
 import Foundation
 
-@MainActor
 internal protocol UINotificationQueueDelegate: AnyObject {
-    
+
     /// Will be called when a new request is ready to be handled.
     /// Will be called immediately if no request is currently running.
     /// If a request is currently handled, this will be called when that request is finished or cancelled.
@@ -19,19 +18,20 @@ internal protocol UINotificationQueueDelegate: AnyObject {
     func handle(_ request: UINotificationRequest)
 }
 
-@MainActor
-internal final class UINotificationQueue {
+internal final class UINotificationQueue: @unchecked Sendable {
 
     /// The currently queued requests.
     internal var requests = [UINotificationRequest]()
     private weak var delegate: UINotificationQueueDelegate?
-    
+
+    /// The queue which is used to make sure the requests array is only modified serially.
+    private let lockQueue = DispatchQueue(label: "com.uinotifications.LockQueue") // Defaults to a serial queue
+
     init(delegate: UINotificationQueueDelegate) {
         self.delegate = delegate
     }
-    
-    /// Adds the given notification to the queue. If `allowDuplicates` is `false`, the returned notification request 
-    /// can have a cancelled state directly after creation.
+
+    /// Adds the given notification to the queue. If `allowDuplicates` is `false`, the returned notification request can have a cancelled state directly after creation.
     ///
     /// - Parameters:
     ///   - notification: The notification which is requested.
@@ -39,18 +39,8 @@ internal final class UINotificationQueue {
     ///   - dismissTrigger: The dismiss trigger which handles dismissing.
     ///   - allowDuplicates: If `true`, the notification will be queued in all cases.
     /// - Returns: The created notification request.
-    @discardableResult func add(
-        _ notification: UINotification,
-        notificationViewType: UINotificationView.Type,
-        dismissTrigger: UINotificationDismissTrigger? = nil,
-        allowDuplicates: Bool = false
-    ) -> UINotificationRequest {
-        let request = UINotificationRequest(
-            notification: notification,
-            delegate: self,
-            notificationViewType: notificationViewType,
-            dismissTrigger: dismissTrigger
-        )
+    @discardableResult func add(_ notification: UINotification, notificationViewType: UINotificationView.Type, dismissTrigger: UINotificationDismissTrigger? = nil, allowDuplicates: Bool = false) -> UINotificationRequest {
+        let request = UINotificationRequest(notification: notification, delegate: self, notificationViewType: notificationViewType, dismissTrigger: dismissTrigger)
 
         if !allowDuplicates, requests.contains(where: { (queuedRequest) -> Bool in
             return queuedRequest.notification == request.notification
@@ -58,29 +48,32 @@ internal final class UINotificationQueue {
             request.cancel()
         }
 
-        if request.state == .idle {
-            requests.append(request)
+        lockQueue.sync {
+            if request.state == .idle {
+                requests.append(request)
+            }
         }
-
         updateRunningRequest()
         return request
     }
-    
+
     internal func remove(_ request: UINotificationRequest) {
-        requests.removeAll(where: { $0 == request })
+        lockQueue.sync {
+            requests.removeAll(where: { $0 == request })
+        }
         updateRunningRequest()
     }
-    
+
     internal func updateRunningRequest() {
         guard requestIsRunning() == false, let request = nextRequestToRun() else { return }
         request.start()
         delegate?.handle(request)
     }
-    
+
     internal func requestIsRunning() -> Bool {
         return requests.lazy.contains(where: { $0.state == .running })
     }
-    
+
     internal func nextRequestToRun() -> UINotificationRequest? {
         return requests.lazy.first(where: { $0.state == .idle })
     }

--- a/Sources/UINotificationRequest.swift
+++ b/Sources/UINotificationRequest.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+@MainActor
 protocol UINotificationRequestDelegate: AnyObject {
     
     /// Notifies of a change inside the passed `UINotificationRequest` state.
@@ -20,8 +21,9 @@ protocol UINotificationRequestDelegate: AnyObject {
 
 /// Defines the request of a notification presentation.
 /// Can be in idle, running or finished state. Can also be in a cancelled state if `cancel()` is called.
+@MainActor
 public final class UINotificationRequest: Equatable {
-    
+
     struct WeakRequestDelegate {
         weak var target: UINotificationRequestDelegate?
     }
@@ -87,7 +89,7 @@ public final class UINotificationRequest: Equatable {
         state = .finished
     }
     
-    public static func == (lhs: UINotificationRequest, rhs: UINotificationRequest) -> Bool {
+    nonisolated public static func == (lhs: UINotificationRequest, rhs: UINotificationRequest) -> Bool {
         return lhs.identifier == rhs.identifier
     }
 }

--- a/Tests/UINotificationCenterTests.swift
+++ b/Tests/UINotificationCenterTests.swift
@@ -65,7 +65,7 @@ final class UINotificationCenterTests: UINotificationTestCase {
         await waitForCondition(notificationCenter.currentPresenter is MockPresenter, timeout: 5.0, description: "Custom presenter should be used for presenting")
     }
     
-    /// When a presentation is finished, the presenter should be releasted.
+    /// When a presentation is finished, the presenter should be released.
     func testPresenterReleasing() async {
         let notificationCenter = UINotificationCenter()
         notificationCenter.configuration = UINotificationCenterConfiguration(

--- a/Tests/UINotificationCenterTests.swift
+++ b/Tests/UINotificationCenterTests.swift
@@ -8,9 +8,17 @@
 
 import XCTest
 @testable import UINotifications
+import ConcurrencyExtras
 
+@MainActor
 final class UINotificationCenterTests: UINotificationTestCase {
     
+    override func invokeTest() {
+        withMainSerialExecutor {
+            super.invokeTest()
+        }
+    }
+
     /// When a notification is requested, it should be added to the queue.
     func testShowNotificationQueue() {
         let notificationCenter = UINotificationCenter()
@@ -26,36 +34,45 @@ final class UINotificationCenterTests: UINotificationTestCase {
     }
     
     /// When a custom default notification view is set, it should be used for presentation.
-    func testCustomDefaultNotificationView() {
+    func testCustomDefaultNotificationView() async {
         let notificationCenter = UINotificationCenter()
-        notificationCenter.defaultNotificationViewType = MockNotificationView.self
+        notificationCenter.configuration = UINotificationCenterConfiguration(
+            defaultNotificationViewType: MockNotificationView.self
+        )
         notificationCenter.show(notification: notification)
+        await Task.yield()
+
         XCTAssert(notificationCenter.currentPresenter?.presentationContext.notificationView is MockNotificationView, "The custom view should be used")
     }
     
     /// When a custom notification view is passed inside the presentation method, it should be used for presentation.
-    func testCustomNotificationView() {
+    func testCustomNotificationView() async {
         let notificationCenter = UINotificationCenter()
         notificationCenter.show(notification: notification, notificationViewType: MockNotificationView.self)
+        await Task.yield()
         XCTAssert(notificationCenter.currentPresenter?.presentationContext.notificationView is MockNotificationView, "The custom view should be used")
     }
     
     /// When a custom presenter is set, it should be used for presenting.
-    func testCustomNotificationPresenter() {
+    func testCustomNotificationPresenter() async {
         let notificationCenter = UINotificationCenter()
-        notificationCenter.presenterType = MockPresenter.self
+        notificationCenter.configuration = UINotificationCenterConfiguration(
+            presenterType: MockPresenter.self
+        )
         
         notificationCenter.show(notification: notification)
-        
-        waitFor(notificationCenter.currentPresenter is MockPresenter, timeout: 5.0, description: "Custom presenter should be used for presenting")
+
+        await waitForCondition(notificationCenter.currentPresenter is MockPresenter, timeout: 5.0, description: "Custom presenter should be used for presenting")
     }
     
     /// When a presentation is finished, the presenter should be releasted.
-    func testPresenterReleasing() {
+    func testPresenterReleasing() async {
         let notificationCenter = UINotificationCenter()
-        notificationCenter.presenterType = MockPresenter.self
+        notificationCenter.configuration = UINotificationCenterConfiguration(
+            presenterType: MockPresenter.self
+        )
         notificationCenter.show(notification: notification)
 
-        waitFor(notificationCenter.currentPresenter == nil, timeout: 5.0, description: "Current presenter should be released and nil")
+        await waitForCondition(notificationCenter.currentPresenter == nil, timeout: 5.0, description: "Current presenter should be released and nil")
     }
 }

--- a/Tests/UINotificationDefaultElementsTests.swift
+++ b/Tests/UINotificationDefaultElementsTests.swift
@@ -67,7 +67,6 @@ final class UINotificationDefaultElementsTests: UINotificationTestCase {
         let presenter = try XCTUnwrap(notificationCenter.currentPresenter as? UINotificationEaseOutEaseInPresenter)
         XCTAssert(notificationCenter.queue.requests.first?.state == .running, "We should have a running notification")
         
-        await Task.megaYield(count: 4)
         await waitForCondition(notificationCenter.queue.requests.isEmpty, timeout: 5.0, description: "All requests should be cleaned up after presentation")
 
         presenter.state = .dismissing

--- a/Tests/UINotificationDefaultViewTests.swift
+++ b/Tests/UINotificationDefaultViewTests.swift
@@ -8,9 +8,17 @@
 
 import XCTest
 @testable import UINotifications
+import ConcurrencyExtras
 
+@MainActor
 final class UINotificationViewTests: UINotificationTestCase {
     
+    override func invokeTest() {
+        withMainSerialExecutor {
+            super.invokeTest()
+        }
+    }
+
     /// When a notification view is tapped, the action trigger should be called.
     func testTapGesture() {
         let expectation = self.expectation(description: "Action should be triggered")
@@ -62,7 +70,7 @@ final class UINotificationViewTests: UINotificationTestCase {
     }
     
     /// When the notification content updates, the view should inherit these changes.
-    func testNotificationContentUpdate() {
+    func testNotificationContentUpdate() async {
         let notificationView = UINotificationView(notification: notification)
         
         XCTAssert(notificationView.titleLabel.text == notification.content.title, "Title should match initial content")
@@ -70,31 +78,34 @@ final class UINotificationViewTests: UINotificationTestCase {
         
         let updatedContent = UINotificationContent(title: "Updated title", subtitle: "Updated subtitle", image: LargeChevronStyle().chevronImage)
         notification.update(updatedContent)
-        
+        await Task.yield()
+
         XCTAssert(notificationView.titleLabel.text == updatedContent.title, "Title of the notification view should update accordingly")
         XCTAssert(notificationView.subtitleLabel.text == updatedContent.subtitle, "Subtitle of the notification view should update accordingly")
         XCTAssert(notificationView.imageView.image == updatedContent.image, "Image of the notification view should update accordingly")
     }
     
     /// It should add the button as a subview when set.
-    func testButton() {
+    func testButton() async {
         let notificationView = UINotificationView(notification: notification)
         
         XCTAssertNil(notificationView.button)
 
         notification.button = UIButton(type: .system)
+        await Task.yield()
         XCTAssertNotNil(notificationView.button)
         XCTAssertNotNil(notificationView.button?.superview)
     }
     
     /// It should add the button as a subview when set, even after the notification is shown.
-    func testButtonAfterShow() {
+    func testButtonAfterShow() async {
         let notificationView = UINotificationView(notification: notification)
 
         UINotificationCenter.current.show(notification: notification, dismissTrigger: nil)
         
         XCTAssertNil(notificationView.button)
         notification.button = UIButton(type: .system)
+        await Task.yield()
         XCTAssertNotNil(notificationView.button)
         XCTAssertNotNil(notificationView.button?.superview)
     }

--- a/Tests/UINotificationTestCase.swift
+++ b/Tests/UINotificationTestCase.swift
@@ -27,7 +27,7 @@ class UINotificationTestCase: XCTestCase {
             self.presentationContext = presentationContext
             self.dismissTrigger = dismissTrigger ?? UINotificationDurationDismissTrigger(duration: 0.0)
         }
-        
+
         func present() {
             dismissTrigger.target = self
             (dismissTrigger as? UINotificationSchedulableDismissTrigger)?.schedule()

--- a/UINotifications.xctestplan
+++ b/UINotifications.xctestplan
@@ -1,0 +1,24 @@
+{
+  "configurations" : [
+    {
+      "id" : "333C68F8-A6C1-435C-903A-129E4BBD2F51",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:",
+        "identifier" : "UINotificationsTests",
+        "name" : "UINotificationsTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,7 +1,7 @@
 # Fastlane requirements
 fastlane_version "1.109.0"
 
-import "./../Submodules/WeTransfer-iOS-CI/Fastlane/Fastfile"
+import "./../Submodules/WeTransfer-iOS-CI/Fastlane/testing_lanes.rb"
 import "./../Submodules/WeTransfer-iOS-CI/Fastlane/shared_lanes.rb"
 
 desc "Run the tests and prepare for Danger"


### PR DESCRIPTION
This PR is a breaking change and introduces support for Swift Concurrency. There are a few important design decisions I made to keep the code changes at implementation level to a minimum and reduce complexity at call side:

- `UINotificationCenter` is unchecked Sendable since all its mutation happens either on the Main Actor or is unlikely going to be in sequence with write operations. I've tried making it a `@MainActor`, but resulted in difficulties throughout the implementation level. For example, calling `UINotificationCenter.current` from a non-mainactor `init` would result in build failures. 
- Since we're queuing notifications, there's no need for the notification center to be accessed on the Main Actor. Presenting happens internally in the framework as triggered from the queue and that part _is_ running on the main actor.
- In general: wherever it made sense, I've added the `@MainActor` attribute. Mostly since we're dealing with user interface notifications

Altogether, the result is a thread-safe solution done by using both Swift Concurrency and lock queues. Check out internal comments for additional context.